### PR TITLE
Add potion status screen

### DIFF
--- a/assets/ui/potionStatusScreen.ui
+++ b/assets/ui/potionStatusScreen.ui
@@ -26,214 +26,53 @@
             "text": "Active Effects"
           },
           {
-            "type": "rowLayout",
-            "horizontalSpacing": 0,
-            "contents": [
-              {
-                "type": "UIImage",
-                "id": "statusIcon1",
-                "image": "engine:icons#emptyIcon"
-              },
-              {
-                "type": "UILabel",
-                "id": "statusName1",
-                "text": "Name"
-              },
-              {
-                "type": "UILabel",
-                "id": "statusDuration1",
-                "text": "Duration"
-              }
-            ]
+            "type": "UILabel",
+            "id": "statusLabel1",
+            "text": "Name"
           },
           {
-            "type": "rowLayout",
-            "horizontalSpacing": 0,
-            "contents": [
-              {
-                "type": "UIImage",
-                "id": "statusIcon2",
-                "image": "engine:icons#emptyIcon"
-              },
-              {
-                "type": "UILabel",
-                "id": "statusName2",
-                "text": "Name"
-              },
-              {
-                "type": "UILabel",
-                "id": "statusDuration2",
-                "text": "Duration"
-              }
-            ]
+            "type": "UILabel",
+            "id": "statusLabel2",
+            "text": "Name"
+          },{
+            "type": "UILabel",
+            "id": "statusLabel3",
+            "text": "Name"
           },
           {
-            "type": "rowLayout",
-            "horizontalSpacing": 0,
-            "contents": [
-              {
-                "type": "UIImage",
-                "id": "statusIcon3",
-                "image": "engine:icons#emptyIcon"
-              },
-              {
-                "type": "UILabel",
-                "id": "statusName3",
-                "text": "Name"
-              },
-              {
-                "type": "UILabel",
-                "id": "statusDuration3",
-                "text": "Duration"
-              }
-            ]
+            "type": "UILabel",
+            "id": "statusLabel4",
+            "text": "Name"
           },
           {
-            "type": "rowLayout",
-            "horizontalSpacing": 0,
-            "contents": [
-              {
-                "type": "UIImage",
-                "id": "statusIcon4",
-                "image": "engine:icons#emptyIcon"
-              },
-              {
-                "type": "UILabel",
-                "id": "statusName4",
-                "text": "Name"
-              },
-              {
-                "type": "UILabel",
-                "id": "statusDuration4",
-                "text": "Duration"
-              }
-            ]
+            "type": "UILabel",
+            "id": "statusLabel5",
+            "text": "Name"
           },
           {
-            "type": "rowLayout",
-            "horizontalSpacing": 0,
-            "contents": [
-              {
-                "type": "UIImage",
-                "id": "statusIcon5",
-                "image": "engine:icons#emptyIcon"
-              },
-              {
-                "type": "UILabel",
-                "id": "statusName5",
-                "text": "Name"
-              },
-              {
-                "type": "UILabel",
-                "id": "statusDuration5",
-                "text": "Duration"
-              }
-            ]
+            "type": "UILabel",
+            "id": "statusLabel6",
+            "text": "Name"
           },
           {
-            "type": "rowLayout",
-            "horizontalSpacing": 0,
-            "contents": [
-              {
-                "type": "UIImage",
-                "id": "statusIcon6",
-                "image": "engine:icons#emptyIcon"
-              },
-              {
-                "type": "UILabel",
-                "id": "statusName6",
-                "text": "Name"
-              },
-              {
-                "type": "UILabel",
-                "id": "statusDuration6",
-                "text": "Duration"
-              }
-            ]
+            "type": "UILabel",
+            "id": "statusLabel7",
+            "text": "Name"
           },
           {
-            "type": "rowLayout",
-            "horizontalSpacing": 0,
-            "contents": [
-              {
-                "type": "UIImage",
-                "id": "statusIcon7",
-                "image": "engine:icons#emptyIcon"
-              },
-              {
-                "type": "UILabel",
-                "id": "statusName7",
-                "text": "Name"
-              },
-              {
-                "type": "UILabel",
-                "id": "statusDuration7",
-                "text": "Duration"
-              }
-            ]
+            "type": "UILabel",
+            "id": "statusLabel8",
+            "text": "Name"
           },
           {
-            "type": "rowLayout",
-            "horizontalSpacing": 0,
-            "contents": [
-              {
-                "type": "UIImage",
-                "id": "statusIcon8",
-                "image": "engine:icons#emptyIcon"
-              },
-              {
-                "type": "UILabel",
-                "id": "statusName8",
-                "text": "Name"
-              },
-              {
-                "type": "UILabel",
-                "id": "statusDuration8",
-                "text": "Duration"
-              }
-            ]
+            "type": "UILabel",
+            "id": "statusLabel9",
+            "text": "Name"
           },
           {
-            "type": "rowLayout",
-            "horizontalSpacing": 0,
-            "contents": [
-              {
-                "type": "UIImage",
-                "id": "statusIcon9",
-                "image": "engine:icons#emptyIcon"
-              },
-              {
-                "type": "UILabel",
-                "id": "statusName9",
-                "text": "Name"
-              },
-              {
-                "type": "UILabel",
-                "id": "statusDuration9",
-                "text": "Duration"
-              }
-            ]
-          },
-          {
-            "type": "rowLayout",
-            "horizontalSpacing": 0,
-            "contents": [
-              {
-                "type": "UIImage",
-                "id": "statusIcon10",
-                "image": "engine:icons#emptyIcon"
-              },
-              {
-                "type": "UILabel",
-                "id": "statusName10",
-                "text": "Name"
-              },
-              {
-                "type": "UILabel",
-                "id": "statusDuration10",
-                "text": "Duration"
-              }
-            ]
+            "type": "UILabel",
+            "id": "statusLabel10",
+            "text": "Name"
           }
         ]
       }

--- a/assets/ui/potionStatusScreen.ui
+++ b/assets/ui/potionStatusScreen.ui
@@ -1,0 +1,153 @@
+{
+  "type": "PotionStatusScreen",
+  "contents": {
+    "type": "relativeLayout",
+    "contents": [
+      {
+        "type": "columnLayout",
+        "layoutInfo": {
+          "width": 300,
+          "use-content-height": true,
+          "position-right": {
+            "target": "RIGHT",
+            "offset": 0
+          },
+          "position-top": {
+            "target": "TOP",
+            "offset": 280
+          }
+        },
+        "columns": 1,
+        "verticalSpacing": 8,
+        "contents": [
+          {
+            "type": "rowLayout",
+            "horizontalSpacing": 0,
+            "contents": [
+              {
+                "type": "UIImage",
+                "id": "statusOneIcon",
+                "image": "engine:icons#redHeart"
+              },
+              {
+                "type": "UILabel",
+                "id": "statusOneName",
+                "text": "Name"
+              },
+              {
+                "type": "UILabel",
+                "id": "statusOneDuration",
+                "text": "Duration"
+              }
+            ]
+          },
+          {
+            "type": "rowLayout",
+            "horizontalSpacing": 0,
+            "contents": [
+              {
+                "type": "UIImage",
+                "id": "statusTwoIcon",
+                "image": "engine:icons#redHeart"
+              },
+              {
+                "type": "UILabel",
+                "id": "statusTwoName",
+                "text": "Name"
+              },
+              {
+                "type": "UILabel",
+                "id": "statusTwoDuration",
+                "text": "Duration"
+              }
+            ]
+          },
+          {
+            "type": "rowLayout",
+            "horizontalSpacing": 0,
+            "contents": [
+              {
+                "type": "UIImage",
+                "id": "statusThreeIcon",
+                "image": "engine:icons#redHeart"
+              },
+              {
+                "type": "UILabel",
+                "id": "statusThreeName",
+                "text": "Name"
+              },
+              {
+                "type": "UILabel",
+                "id": "statusThreeDuration",
+                "text": "Duration"
+              }
+            ]
+          },
+          {
+            "type": "rowLayout",
+            "horizontalSpacing": 0,
+            "contents": [
+              {
+                "type": "UIImage",
+                "id": "statusFourIcon",
+                "image": "engine:icons#redHeart"
+              },
+              {
+                "type": "UILabel",
+                "id": "statusFourName",
+                "text": "Name"
+              },
+              {
+                "type": "UILabel",
+                "id": "statusFourDuration",
+                "text": "Duration"
+              }
+            ]
+          },
+          {
+            "type": "rowLayout",
+            "horizontalSpacing": 0,
+            "contents": [
+              {
+                "type": "UIImage",
+                "id": "statusFiveIcon",
+                "image": "engine:icons#redHeart"
+              },
+              {
+                "type": "UILabel",
+                "id": "statusFiveName",
+                "text": "Name"
+              },
+              {
+                "type": "UILabel",
+                "id": "statusFiveDuration",
+                "text": "Duration"
+              }
+            ]
+          },
+          {
+            "type": "rowLayout",
+            "horizontalSpacing": 0,
+            "contents": [
+              {
+                "type": "UIImage",
+                "id": "statusSixIcon",
+                "image": "engine:icons#redHeart"
+              },
+              {
+                "type": "UILabel",
+                "id": "statusSixName",
+                "text": "Name"
+              },
+              {
+                "type": "UILabel",
+                "id": "statusSixDuration",
+                "text": "Duration"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/assets/ui/potionStatusScreen.ui
+++ b/assets/ui/potionStatusScreen.ui
@@ -21,22 +21,27 @@
         "verticalSpacing": 8,
         "contents": [
           {
+            "type": "UILabel",
+            "id": "PotionStatusLabel",
+            "text": "Active Effects"
+          },
+          {
             "type": "rowLayout",
             "horizontalSpacing": 0,
             "contents": [
               {
                 "type": "UIImage",
-                "id": "statusOneIcon",
-                "image": "engine:icons#redHeart"
+                "id": "statusIcon1",
+                "image": "engine:icons#emptyIcon"
               },
               {
                 "type": "UILabel",
-                "id": "statusOneName",
+                "id": "statusName1",
                 "text": "Name"
               },
               {
                 "type": "UILabel",
-                "id": "statusOneDuration",
+                "id": "statusDuration1",
                 "text": "Duration"
               }
             ]
@@ -47,17 +52,17 @@
             "contents": [
               {
                 "type": "UIImage",
-                "id": "statusTwoIcon",
-                "image": "engine:icons#redHeart"
+                "id": "statusIcon2",
+                "image": "engine:icons#emptyIcon"
               },
               {
                 "type": "UILabel",
-                "id": "statusTwoName",
+                "id": "statusName2",
                 "text": "Name"
               },
               {
                 "type": "UILabel",
-                "id": "statusTwoDuration",
+                "id": "statusDuration2",
                 "text": "Duration"
               }
             ]
@@ -68,17 +73,17 @@
             "contents": [
               {
                 "type": "UIImage",
-                "id": "statusThreeIcon",
-                "image": "engine:icons#redHeart"
+                "id": "statusIcon3",
+                "image": "engine:icons#emptyIcon"
               },
               {
                 "type": "UILabel",
-                "id": "statusThreeName",
+                "id": "statusName3",
                 "text": "Name"
               },
               {
                 "type": "UILabel",
-                "id": "statusThreeDuration",
+                "id": "statusDuration3",
                 "text": "Duration"
               }
             ]
@@ -89,17 +94,17 @@
             "contents": [
               {
                 "type": "UIImage",
-                "id": "statusFourIcon",
-                "image": "engine:icons#redHeart"
+                "id": "statusIcon4",
+                "image": "engine:icons#emptyIcon"
               },
               {
                 "type": "UILabel",
-                "id": "statusFourName",
+                "id": "statusName4",
                 "text": "Name"
               },
               {
                 "type": "UILabel",
-                "id": "statusFourDuration",
+                "id": "statusDuration4",
                 "text": "Duration"
               }
             ]
@@ -110,17 +115,17 @@
             "contents": [
               {
                 "type": "UIImage",
-                "id": "statusFiveIcon",
-                "image": "engine:icons#redHeart"
+                "id": "statusIcon5",
+                "image": "engine:icons#emptyIcon"
               },
               {
                 "type": "UILabel",
-                "id": "statusFiveName",
+                "id": "statusName5",
                 "text": "Name"
               },
               {
                 "type": "UILabel",
-                "id": "statusFiveDuration",
+                "id": "statusDuration5",
                 "text": "Duration"
               }
             ]
@@ -131,17 +136,101 @@
             "contents": [
               {
                 "type": "UIImage",
-                "id": "statusSixIcon",
-                "image": "engine:icons#redHeart"
+                "id": "statusIcon6",
+                "image": "engine:icons#emptyIcon"
               },
               {
                 "type": "UILabel",
-                "id": "statusSixName",
+                "id": "statusName6",
                 "text": "Name"
               },
               {
                 "type": "UILabel",
-                "id": "statusSixDuration",
+                "id": "statusDuration6",
+                "text": "Duration"
+              }
+            ]
+          },
+          {
+            "type": "rowLayout",
+            "horizontalSpacing": 0,
+            "contents": [
+              {
+                "type": "UIImage",
+                "id": "statusIcon7",
+                "image": "engine:icons#emptyIcon"
+              },
+              {
+                "type": "UILabel",
+                "id": "statusName7",
+                "text": "Name"
+              },
+              {
+                "type": "UILabel",
+                "id": "statusDuration7",
+                "text": "Duration"
+              }
+            ]
+          },
+          {
+            "type": "rowLayout",
+            "horizontalSpacing": 0,
+            "contents": [
+              {
+                "type": "UIImage",
+                "id": "statusIcon8",
+                "image": "engine:icons#emptyIcon"
+              },
+              {
+                "type": "UILabel",
+                "id": "statusName8",
+                "text": "Name"
+              },
+              {
+                "type": "UILabel",
+                "id": "statusDuration8",
+                "text": "Duration"
+              }
+            ]
+          },
+          {
+            "type": "rowLayout",
+            "horizontalSpacing": 0,
+            "contents": [
+              {
+                "type": "UIImage",
+                "id": "statusIcon9",
+                "image": "engine:icons#emptyIcon"
+              },
+              {
+                "type": "UILabel",
+                "id": "statusName9",
+                "text": "Name"
+              },
+              {
+                "type": "UILabel",
+                "id": "statusDuration9",
+                "text": "Duration"
+              }
+            ]
+          },
+          {
+            "type": "rowLayout",
+            "horizontalSpacing": 0,
+            "contents": [
+              {
+                "type": "UIImage",
+                "id": "statusIcon10",
+                "image": "engine:icons#emptyIcon"
+              },
+              {
+                "type": "UILabel",
+                "id": "statusName10",
+                "text": "Name"
+              },
+              {
+                "type": "UILabel",
+                "id": "statusDuration10",
                 "text": "Duration"
               }
             ]

--- a/src/main/java/org/terasology/potions/PotionStatusScreen.java
+++ b/src/main/java/org/terasology/potions/PotionStatusScreen.java
@@ -17,14 +17,10 @@ package org.terasology.potions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.terasology.potions.component.PotionEffect;
-import org.terasology.rendering.assets.texture.TextureRegion;
 import org.terasology.rendering.nui.CoreScreenLayer;
 import org.terasology.rendering.nui.widgets.UIImage;
 import org.terasology.rendering.nui.widgets.UILabel;
 import org.terasology.utilities.Assets;
-
-import java.util.Arrays;
 
 public class PotionStatusScreen extends CoreScreenLayer {
     private static final Logger logger = LoggerFactory.getLogger(PotionStatusScreen.class);
@@ -40,24 +36,20 @@ public class PotionStatusScreen extends CoreScreenLayer {
             statusNames[i] = find("statusName" + (i + 1), UILabel.class);
             statusDurations[i] = find("statusDuration" + (i + 1), UILabel.class);
         }
-        logger.info(find("statusIcon1", UIImage.class).toString());
-        for (int i = 0; i < 10; i++) {
-            removeEffect(i);
-        }
+        removeAll();
     }
 
     public void addEffect(int index, String name, long duration) {
-//        TextureRegion icon =  Assets.getTextureRegion("potions:effectIcons#" + name).get();
-  //      icon = icon != null ? icon : Assets.getTextureRegion("engine:icons#emptyIcon").get();
-    //    statusIcons[index].setImage(icon);
         statusNames[index].setText(name);
         statusDurations[index].setText(String.valueOf(duration));
     }
 
-    public void removeEffect(int index) {
-        statusIcons[index].setImage(Assets.getTextureRegion("engine:icons#emptyIcon").get());
-        statusNames[index].setText("");
-        statusDurations[index].setText("");
+    public void removeAll() {
+        for (int i = 0; i < 10; i++) {
+            statusIcons[i].setImage(Assets.getTextureRegion("engine:icons#emptyIcon").get());
+            statusNames[i].setText("");
+            statusDurations[i].setText("");
+        }
     }
 
     @Override

--- a/src/main/java/org/terasology/potions/PotionStatusScreen.java
+++ b/src/main/java/org/terasology/potions/PotionStatusScreen.java
@@ -15,22 +15,15 @@
  */
 package org.terasology.potions;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
-import org.terasology.input.BindButtonEvent;
-import org.terasology.input.binds.inventory.InventoryButton;
 import org.terasology.rendering.nui.CoreScreenLayer;
 
 @RegisterSystem(RegisterMode.CLIENT)
 public class PotionStatusScreen extends CoreScreenLayer {
-    private static final Logger logger = LoggerFactory.getLogger(PotionStatusScreen.class);
 
     @Override
     public void initialise() {
-        logger.info("Potions init");
     }
 
     @Override

--- a/src/main/java/org/terasology/potions/PotionStatusScreen.java
+++ b/src/main/java/org/terasology/potions/PotionStatusScreen.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.potions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.input.BindButtonEvent;
+import org.terasology.input.binds.inventory.InventoryButton;
+import org.terasology.rendering.nui.CoreScreenLayer;
+
+@RegisterSystem(RegisterMode.CLIENT)
+public class PotionStatusScreen extends CoreScreenLayer {
+    private static final Logger logger = LoggerFactory.getLogger(PotionStatusScreen.class);
+
+    @Override
+    public void initialise() {
+        logger.info("Potions init");
+    }
+
+    @Override
+    @ReceiveEvent(priority = 101)
+    public void onBindEvent(BindButtonEvent event) {
+        if (event instanceof InventoryButton && event.isDown()) {
+            logger.info("Potions Close");
+            getManager().closeScreen(this);
+        }
+    }
+}

--- a/src/main/java/org/terasology/potions/PotionStatusScreen.java
+++ b/src/main/java/org/terasology/potions/PotionStatusScreen.java
@@ -15,15 +15,10 @@
  */
 package org.terasology.potions;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terasology.rendering.nui.CoreScreenLayer;
-import org.terasology.rendering.nui.widgets.UIImage;
 import org.terasology.rendering.nui.widgets.UILabel;
-import org.terasology.utilities.Assets;
 
 public class PotionStatusScreen extends CoreScreenLayer {
-    private static final Logger logger = LoggerFactory.getLogger(PotionStatusScreen.class);
 
     private UILabel[] statusLabels = new UILabel[10];
 

--- a/src/main/java/org/terasology/potions/PotionStatusScreen.java
+++ b/src/main/java/org/terasology/potions/PotionStatusScreen.java
@@ -34,11 +34,7 @@ public class PotionStatusScreen extends CoreScreenLayer {
     }
 
     @Override
-    @ReceiveEvent(priority = 101)
-    public void onBindEvent(BindButtonEvent event) {
-        if (event instanceof InventoryButton && event.isDown()) {
-            logger.info("Potions Close");
-            getManager().closeScreen(this);
-        }
+    public boolean isModal() {
+        return false;
     }
 }

--- a/src/main/java/org/terasology/potions/PotionStatusScreen.java
+++ b/src/main/java/org/terasology/potions/PotionStatusScreen.java
@@ -15,15 +15,49 @@
  */
 package org.terasology.potions;
 
-import org.terasology.entitySystem.systems.RegisterMode;
-import org.terasology.entitySystem.systems.RegisterSystem;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.potions.component.PotionEffect;
+import org.terasology.rendering.assets.texture.TextureRegion;
 import org.terasology.rendering.nui.CoreScreenLayer;
+import org.terasology.rendering.nui.widgets.UIImage;
+import org.terasology.rendering.nui.widgets.UILabel;
+import org.terasology.utilities.Assets;
 
-@RegisterSystem(RegisterMode.CLIENT)
+import java.util.Arrays;
+
 public class PotionStatusScreen extends CoreScreenLayer {
+    private static final Logger logger = LoggerFactory.getLogger(PotionStatusScreen.class);
+
+    private UIImage[] statusIcons = new UIImage[10];
+    private UILabel[] statusNames = new UILabel[10];
+    private UILabel[] statusDurations = new UILabel[10];
 
     @Override
     public void initialise() {
+        for (int i = 0; i < 10; i++) {
+            statusIcons[i] = find("statusIcon" + (i + 1), UIImage.class);
+            statusNames[i] = find("statusName" + (i + 1), UILabel.class);
+            statusDurations[i] = find("statusDuration" + (i + 1), UILabel.class);
+        }
+        logger.info(find("statusIcon1", UIImage.class).toString());
+        for (int i = 0; i < 10; i++) {
+            removeEffect(i);
+        }
+    }
+
+    public void addEffect(int index, String name, long duration) {
+//        TextureRegion icon =  Assets.getTextureRegion("potions:effectIcons#" + name).get();
+  //      icon = icon != null ? icon : Assets.getTextureRegion("engine:icons#emptyIcon").get();
+    //    statusIcons[index].setImage(icon);
+        statusNames[index].setText(name);
+        statusDurations[index].setText(String.valueOf(duration));
+    }
+
+    public void removeEffect(int index) {
+        statusIcons[index].setImage(Assets.getTextureRegion("engine:icons#emptyIcon").get());
+        statusNames[index].setText("");
+        statusDurations[index].setText("");
     }
 
     @Override

--- a/src/main/java/org/terasology/potions/PotionStatusScreen.java
+++ b/src/main/java/org/terasology/potions/PotionStatusScreen.java
@@ -25,31 +25,45 @@ import org.terasology.utilities.Assets;
 public class PotionStatusScreen extends CoreScreenLayer {
     private static final Logger logger = LoggerFactory.getLogger(PotionStatusScreen.class);
 
-    private UIImage[] statusIcons = new UIImage[10];
-    private UILabel[] statusNames = new UILabel[10];
-    private UILabel[] statusDurations = new UILabel[10];
+    private UILabel[] statusLabels = new UILabel[10];
 
     @Override
     public void initialise() {
         for (int i = 0; i < 10; i++) {
-            statusIcons[i] = find("statusIcon" + (i + 1), UIImage.class);
-            statusNames[i] = find("statusName" + (i + 1), UILabel.class);
-            statusDurations[i] = find("statusDuration" + (i + 1), UILabel.class);
+            statusLabels[i] = find("statusLabel" + (i + 1), UILabel.class);
         }
         removeAll();
     }
 
     public void addEffect(int index, String name, long duration) {
-        statusNames[index].setText(name);
-        statusDurations[index].setText(String.valueOf(duration));
+        statusLabels[index].setText(toTitleCase(name) + " " + (duration / 1000) + "s");
     }
 
     public void removeAll() {
         for (int i = 0; i < 10; i++) {
-            statusIcons[i].setImage(Assets.getTextureRegion("engine:icons#emptyIcon").get());
-            statusNames[i].setText("");
-            statusDurations[i].setText("");
+            statusLabels[i].setText("");
         }
+    }
+
+    //Tweaked from http://stackoverflow.com/a/1086134
+    @Deprecated
+    public static String toTitleCase(String input) {
+        input = input.replace('_', ' ').toLowerCase();
+        StringBuilder titleCase = new StringBuilder();
+        boolean nextTitleCase = true;
+
+        for (char c : input.toCharArray()) {
+            if (Character.isSpaceChar(c)) {
+                nextTitleCase = true;
+            } else if (nextTitleCase) {
+                c = Character.toTitleCase(c);
+                nextTitleCase = false;
+            }
+
+            titleCase.append(c);
+        }
+
+        return titleCase.toString();
     }
 
     @Override

--- a/src/main/java/org/terasology/potions/PotionStatusUISystem.java
+++ b/src/main/java/org/terasology/potions/PotionStatusUISystem.java
@@ -15,9 +15,6 @@
  */
 package org.terasology.potions;
 
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
@@ -30,16 +27,12 @@ import org.terasology.rendering.nui.NUIManager;
 
 @RegisterSystem(RegisterMode.CLIENT)
 public class PotionStatusUISystem extends BaseComponentSystem {
-
-    private static final Logger logger = LoggerFactory.getLogger(PotionStatusUISystem.class);
-
     @In
     private NUIManager nuiManager;
 
     @ReceiveEvent(priority = 101)
     public void inventoryToggled(InventoryButton event, EntityRef entity) {
         if (event.getState() == ButtonState.DOWN) {
-            logger.info("Potions Open");
             nuiManager.toggleScreen("potions:PotionStatusScreen");
         }
     }

--- a/src/main/java/org/terasology/potions/PotionStatusUISystem.java
+++ b/src/main/java/org/terasology/potions/PotionStatusUISystem.java
@@ -55,13 +55,14 @@ public class PotionStatusUISystem extends BaseComponentSystem {
 
     private boolean isScreenVisible = false;
 
+    private int updateRate = 200;
+
     @Override
     public void initialise() {
     }
 
     @ReceiveEvent(priority = 110)
     public void inventoryToggled(InventoryButton event, EntityRef entity) {
-
         logger.info("inv toggle: " + entity.toString());
         if (event.getState() == ButtonState.DOWN) {
             nuiManager.toggleScreen("potions:potionStatusScreen");
@@ -79,7 +80,7 @@ public class PotionStatusUISystem extends BaseComponentSystem {
             if (index == -1) {
                 effects.add(effect.effect);
                 durations.add(effect.duration);
-                delayManager.addPeriodicAction(entity, "PUI" + effect.effect, 500, 500);
+                delayManager.addPeriodicAction(entity, "PUI" + effect.effect, updateRate, updateRate);
             } else {
                 effects.set(index, effect.effect);
                 durations.set(index, effect.duration);
@@ -95,7 +96,7 @@ public class PotionStatusUISystem extends BaseComponentSystem {
         if (actionID.startsWith("PUI")) {
             logger.info(actionID.substring(3));
             int index = effects.indexOf(actionID.substring(3));
-            durations.set(index, durations.get(index) - 500);
+            durations.set(index, durations.get(index) - updateRate);
             if (durations.get(index) < 0) {
                 durations.remove(index);
                 effects.remove(index);

--- a/src/main/java/org/terasology/potions/PotionStatusUISystem.java
+++ b/src/main/java/org/terasology/potions/PotionStatusUISystem.java
@@ -15,8 +15,6 @@
  */
 package org.terasology.potions;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.EventPriority;
@@ -28,7 +26,6 @@ import org.terasology.input.ButtonState;
 import org.terasology.input.binds.inventory.InventoryButton;
 import org.terasology.logic.delay.DelayManager;
 import org.terasology.logic.delay.PeriodicActionTriggeredEvent;
-import org.terasology.logic.players.LocalPlayer;
 import org.terasology.potions.component.PotionEffect;
 import org.terasology.potions.events.DrinkPotionEvent;
 import org.terasology.registry.In;
@@ -39,7 +36,6 @@ import java.util.ArrayList;
 
 @RegisterSystem(RegisterMode.CLIENT)
 public class PotionStatusUISystem extends BaseComponentSystem {
-    private static final Logger logger = LoggerFactory.getLogger(PotionStatusUISystem.class);
 
     @In
     private NUIManager nuiManager;
@@ -63,7 +59,6 @@ public class PotionStatusUISystem extends BaseComponentSystem {
 
     @ReceiveEvent(priority = 110)
     public void inventoryToggled(InventoryButton event, EntityRef entity) {
-        logger.info("inv toggle: " + entity.toString());
         if (event.getState() == ButtonState.DOWN) {
             nuiManager.toggleScreen("potions:potionStatusScreen");
             isScreenVisible = nuiManager.isOpen("potions:potionStatusScreen");
@@ -74,7 +69,6 @@ public class PotionStatusUISystem extends BaseComponentSystem {
     @ReceiveEvent(priority = EventPriority.PRIORITY_HIGH)
     public void onPotionDrink(DrinkPotionEvent event, EntityRef entity) {
 
-        logger.info("drink: " + entity.toString());
         for (PotionEffect effect : event.getPotionComponent().effects) {
             int index = effects.indexOf(effect);
             if (index == -1) {
@@ -91,10 +85,8 @@ public class PotionStatusUISystem extends BaseComponentSystem {
 
     @ReceiveEvent
     public void onEffectUpdate(PeriodicActionTriggeredEvent event, EntityRef entity) {
-        logger.info("Periodic Activated");
         String actionID = event.getActionId();
         if (actionID.startsWith("PUI")) {
-            logger.info(actionID.substring(3));
             int index = effects.indexOf(actionID.substring(3));
             durations.set(index, durations.get(index) - updateRate);
             if (durations.get(index) < 0) {

--- a/src/main/java/org/terasology/potions/PotionStatusUISystem.java
+++ b/src/main/java/org/terasology/potions/PotionStatusUISystem.java
@@ -17,6 +17,7 @@ package org.terasology.potions;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
@@ -27,10 +28,13 @@ import org.terasology.input.ButtonState;
 import org.terasology.input.binds.inventory.InventoryButton;
 import org.terasology.logic.delay.DelayManager;
 import org.terasology.logic.delay.PeriodicActionTriggeredEvent;
+import org.terasology.logic.players.LocalPlayer;
 import org.terasology.potions.component.PotionEffect;
 import org.terasology.potions.events.DrinkPotionEvent;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.NUIManager;
+
+import java.util.ArrayList;
 
 
 @RegisterSystem(RegisterMode.CLIENT)
@@ -39,87 +43,75 @@ public class PotionStatusUISystem extends BaseComponentSystem {
 
     @In
     private NUIManager nuiManager;
-
     @In
     private DelayManager delayManager;
+    @In
+    private EntityManager entityManager;
 
     private PotionStatusScreen screen;
 
-    private long[] durations = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-    private PotionEffect[] effects = new PotionEffect[10];
+    private ArrayList<Long> durations = new ArrayList<>();
+    private ArrayList<String> effects = new ArrayList<>();
+
     private boolean isScreenVisible = false;
+
+    @Override
+    public void initialise() {
+    }
 
     @ReceiveEvent(priority = 110)
     public void inventoryToggled(InventoryButton event, EntityRef entity) {
+
+        logger.info("inv toggle: " + entity.toString());
         if (event.getState() == ButtonState.DOWN) {
             nuiManager.toggleScreen("potions:potionStatusScreen");
             isScreenVisible = nuiManager.isOpen("potions:potionStatusScreen");
-            if (isScreenVisible) {
-                screen = (PotionStatusScreen) nuiManager.getScreen("potions:potionStatusScreen");
-                for (int i = 0; i < 10; i++) {
-                    if (effects[i] != null) {
-                        screen.addEffect(i, effects[i].effect, durations[i]);
-                    } else {
-                        screen.removeEffect(i);
-                    }
-                }
-            }
+            updateScreen();
         }
     }
 
     @ReceiveEvent(priority = EventPriority.PRIORITY_HIGH)
     public void onPotionDrink(DrinkPotionEvent event, EntityRef entity) {
-        logger.info(event.toString());
+
+        logger.info("drink: " + entity.toString());
         for (PotionEffect effect : event.getPotionComponent().effects) {
-            for (int i = 0; i < 10; i++) {
-                if (effects[i] == null || effects[i] == effect) {
-                    logger.info(String.valueOf(effect.duration));
-                    durations[i] = effect.duration;
-                    effects[i] = effect;
-                    if (isScreenVisible) {
-                        screen = (PotionStatusScreen) nuiManager.getScreen("potions:potionStatusScreen");
-                        screen.addEffect(i, effect.effect, effect.duration);
-                    }
-                    delayManager.addPeriodicAction(entity, "PotionEffectUpdater" + i, 500, 500);
-                    break;
-                }
+            int index = effects.indexOf(effect);
+            if (index == -1) {
+                effects.add(effect.effect);
+                durations.add(effect.duration);
+                delayManager.addPeriodicAction(entity, "PUI" + effect.effect, 500, 500);
+            } else {
+                effects.set(index, effect.effect);
+                durations.set(index, effect.duration);
             }
         }
+        updateScreen();
     }
 
     @ReceiveEvent
     public void onEffectUpdate(PeriodicActionTriggeredEvent event, EntityRef entity) {
+        logger.info("Periodic Activated");
         String actionID = event.getActionId();
-        if (actionID.startsWith("PotionEffectUpdater")) {
-            logger.info(actionID);
-            int index = Character.getNumericValue(actionID.charAt(actionID.length() - 1));
-            logger.info(String.valueOf(index));
-            durations[index] -= 500;
-            if (durations[index] <= 0) {
-                logger.info(String.valueOf(durations[index]));
-                effects[index] = null;
-                durations[index] = 0;
-                bubbleEffectsUp(index);
+        if (actionID.startsWith("PUI")) {
+            logger.info(actionID.substring(3));
+            int index = effects.indexOf(actionID.substring(3));
+            durations.set(index, durations.get(index) - 500);
+            if (durations.get(index) < 0) {
+                durations.remove(index);
+                effects.remove(index);
                 delayManager.cancelPeriodicAction(entity, actionID);
             }
-            if (isScreenVisible) {
-                logger.info("Display shown");
-                screen = (PotionStatusScreen) nuiManager.getScreen("potions:potionStatusScreen");
-                if (effects[index] == null) {
-                    screen.removeEffect(index);
-                } else {
-                    screen.addEffect(index, effects[index].effect, durations[index]);
-                }
-            }
+            updateScreen();
         }
     }
 
-    private void bubbleEffectsUp(int start) {
-        for (int q = start; q < 9; q++) {
-            effects[q] = effects[q + 1];
-            durations[q] = durations[q + 1];
-            effects[q + 1] = null;
-            durations[q + 1] = 0;
+    private void updateScreen() {
+        if (isScreenVisible) {
+            screen = (PotionStatusScreen) nuiManager.getScreen("potions:potionStatusScreen");
+            screen.removeAll();
+            for (int i = 0; i < Math.min(10, effects.size()); i++) {
+                screen.addEffect(i, effects.get(i), durations.get(i));
+            }
         }
     }
 }

--- a/src/main/java/org/terasology/potions/PotionStatusUISystem.java
+++ b/src/main/java/org/terasology/potions/PotionStatusUISystem.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2016 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.potions;
+
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.ReceiveEvent;
+import org.terasology.entitySystem.systems.BaseComponentSystem;
+import org.terasology.entitySystem.systems.RegisterMode;
+import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.input.ButtonState;
+import org.terasology.input.binds.inventory.InventoryButton;
+import org.terasology.registry.In;
+import org.terasology.rendering.nui.NUIManager;
+
+@RegisterSystem(RegisterMode.CLIENT)
+public class PotionStatusUISystem extends BaseComponentSystem {
+
+    private static final Logger logger = LoggerFactory.getLogger(PotionStatusUISystem.class);
+
+    @In
+    private NUIManager nuiManager;
+
+    @ReceiveEvent(priority = 101)
+    public void inventoryToggled(InventoryButton event, EntityRef entity) {
+        if (event.getState() == ButtonState.DOWN) {
+            logger.info("Potions Open");
+            nuiManager.toggleScreen("potions:PotionStatusScreen");
+        }
+    }
+}

--- a/src/main/java/org/terasology/potions/PotionStatusUISystem.java
+++ b/src/main/java/org/terasology/potions/PotionStatusUISystem.java
@@ -15,25 +15,111 @@
  */
 package org.terasology.potions;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.entitySystem.event.EventPriority;
 import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
 import org.terasology.input.ButtonState;
 import org.terasology.input.binds.inventory.InventoryButton;
+import org.terasology.logic.delay.DelayManager;
+import org.terasology.logic.delay.PeriodicActionTriggeredEvent;
+import org.terasology.potions.component.PotionEffect;
+import org.terasology.potions.events.DrinkPotionEvent;
 import org.terasology.registry.In;
 import org.terasology.rendering.nui.NUIManager;
 
+
 @RegisterSystem(RegisterMode.CLIENT)
 public class PotionStatusUISystem extends BaseComponentSystem {
+    private static final Logger logger = LoggerFactory.getLogger(PotionStatusUISystem.class);
+
     @In
     private NUIManager nuiManager;
 
-    @ReceiveEvent(priority = 101)
+    @In
+    private DelayManager delayManager;
+
+    private PotionStatusScreen screen;
+
+    private long[] durations = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+    private PotionEffect[] effects = new PotionEffect[10];
+    private boolean isScreenVisible = false;
+
+    @ReceiveEvent(priority = 110)
     public void inventoryToggled(InventoryButton event, EntityRef entity) {
         if (event.getState() == ButtonState.DOWN) {
-            nuiManager.toggleScreen("potions:PotionStatusScreen");
+            nuiManager.toggleScreen("potions:potionStatusScreen");
+            isScreenVisible = nuiManager.isOpen("potions:potionStatusScreen");
+            if (isScreenVisible) {
+                screen = (PotionStatusScreen) nuiManager.getScreen("potions:potionStatusScreen");
+                for (int i = 0; i < 10; i++) {
+                    if (effects[i] != null) {
+                        screen.addEffect(i, effects[i].effect, durations[i]);
+                    } else {
+                        screen.removeEffect(i);
+                    }
+                }
+            }
+        }
+    }
+
+    @ReceiveEvent(priority = EventPriority.PRIORITY_HIGH)
+    public void onPotionDrink(DrinkPotionEvent event, EntityRef entity) {
+        logger.info(event.toString());
+        for (PotionEffect effect : event.getPotionComponent().effects) {
+            for (int i = 0; i < 10; i++) {
+                if (effects[i] == null || effects[i] == effect) {
+                    logger.info(String.valueOf(effect.duration));
+                    durations[i] = effect.duration;
+                    effects[i] = effect;
+                    if (isScreenVisible) {
+                        screen = (PotionStatusScreen) nuiManager.getScreen("potions:potionStatusScreen");
+                        screen.addEffect(i, effect.effect, effect.duration);
+                    }
+                    delayManager.addPeriodicAction(entity, "PotionEffectUpdater" + i, 500, 500);
+                    break;
+                }
+            }
+        }
+    }
+
+    @ReceiveEvent
+    public void onEffectUpdate(PeriodicActionTriggeredEvent event, EntityRef entity) {
+        String actionID = event.getActionId();
+        if (actionID.startsWith("PotionEffectUpdater")) {
+            logger.info(actionID);
+            int index = Character.getNumericValue(actionID.charAt(actionID.length() - 1));
+            logger.info(String.valueOf(index));
+            durations[index] -= 500;
+            if (durations[index] <= 0) {
+                logger.info(String.valueOf(durations[index]));
+                effects[index] = null;
+                durations[index] = 0;
+                bubbleEffectsUp(index);
+                delayManager.cancelPeriodicAction(entity, actionID);
+            }
+            if (isScreenVisible) {
+                logger.info("Display shown");
+                screen = (PotionStatusScreen) nuiManager.getScreen("potions:potionStatusScreen");
+                if (effects[index] == null) {
+                    screen.removeEffect(index);
+                } else {
+                    screen.addEffect(index, effects[index].effect, durations[index]);
+                }
+            }
+        }
+    }
+
+    private void bubbleEffectsUp(int start) {
+        for (int q = start; q < 9; q++) {
+            effects[q] = effects[q + 1];
+            durations[q] = durations[q + 1];
+            effects[q + 1] = null;
+            durations[q + 1] = 0;
         }
     }
 }


### PR DESCRIPTION
Add a screen to list the active effects from potions and the remaining time.

The screen is opened using `i` alongside the inventory.