### PR TITLE
#29 log into the console when an invalid potion effect is used

### DIFF
--- a/src/main/java/org/terasology/potions/effect/DoNothingEffect.java
+++ b/src/main/java/org/terasology/potions/effect/DoNothingEffect.java
@@ -16,6 +16,8 @@
 package org.terasology.potions.effect;
 
 import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.logic.console.Console;
+import org.terasology.logic.console.CoreMessageType;
 import org.terasology.potions.HerbEffect;
 
 /**
@@ -23,8 +25,20 @@ import org.terasology.potions.HerbEffect;
  * in case one or more of the listed effects in prefabs are invalid.
  */
 public class DoNothingEffect implements HerbEffect {
+    private final Console console;
+    private final String invalidEffectName;
+
     /**
-     * Do nothing when attempting to apply an effect to the given entity.
+     *
+     * @param console The console where an error message will be printed when the invalid effect is triggered
+     */
+    public DoNothingEffect(Console console, String invalidEffectName) {
+        this.console = console;
+        this.invalidEffectName = invalidEffectName;
+    }
+
+    /**
+     * Log an error message when attempting to apply an effect to the given entity.
      *
      * @param instigator    The instigator who is applying this effect on the entity. It can be a herb, potion, etc.
      * @param entity        The entity who the herb effect is being applied on.
@@ -33,10 +47,11 @@ public class DoNothingEffect implements HerbEffect {
      */
     @Override
     public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
+        logErrorMessage();
     }
 
     /**
-     * Do nothing when attempting to apply an effect to the given entity.
+     * Log an error message when attempting to apply an effect to the given entity.
      *
      * @param instigator    The instigator who is applying this effect on the entity. It can be a herb, potion, etc.
      * @param entity        The entity who the herb effect is being applied on.
@@ -47,5 +62,15 @@ public class DoNothingEffect implements HerbEffect {
      */
     @Override
     public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
+        logErrorMessage();
+    }
+
+    /**
+     * Log the name of the invalid potion effect to the game console
+     */
+    private void logErrorMessage() {
+        if(console != null) {
+            console.addMessage("Cannot find potion effect: " + invalidEffectName, CoreMessageType.ERROR);
+        }
     }
 }

--- a/src/main/java/org/terasology/potions/system/DrinkPotionAuthoritySystem.java
+++ b/src/main/java/org/terasology/potions/system/DrinkPotionAuthoritySystem.java
@@ -37,6 +37,7 @@ import org.terasology.entitySystem.event.ReceiveEvent;
 import org.terasology.entitySystem.systems.BaseComponentSystem;
 import org.terasology.entitySystem.systems.RegisterMode;
 import org.terasology.entitySystem.systems.RegisterSystem;
+import org.terasology.logic.console.Console;
 import org.terasology.logic.inventory.InventoryManager;
 import org.terasology.potions.HerbEffect;
 import org.terasology.potions.PotionCommonEffects;
@@ -246,7 +247,7 @@ public class DrinkPotionAuthoritySystem extends BaseComponentSystem {
                     herbEffect = new NoVisibilityEffect();
                     break;
                 default:
-                    herbEffect = new DoNothingEffect();
+                    herbEffect = new DoNothingEffect(context.get(Console.class), pEffect.effect);
                     break;
             }
 


### PR DESCRIPTION
Closes #29 

When a potion is drank, and the effect is invalid, e.g.: has a typo in the asset file, an error message will be printed to the console.

![potioneffecterror](https://cloud.githubusercontent.com/assets/18668703/23839850/16e8bd0c-07a1-11e7-9ee5-8781a4b1d959.jpg)
Steps to Test

Open a potion asset, and modify the effect to something invalid. E.g.: open HarmPotion.prefab and change the effect to "HAAAARM"
Start up the game and create/open a world with the Potions module enabled
Add the potion from the console (give Potions:HarmPotion) and use it with right click
Expected Result: The effect will not happen; a red error message will appear in the console window.