### PR TITLE
Update HealEffects to depend on restoration logic

### DIFF
--- a/src/main/java/org/terasology/potions/effect/ExplosiveEffect.java
+++ b/src/main/java/org/terasology/potions/effect/ExplosiveEffect.java
@@ -15,15 +15,9 @@
  */
 package org.terasology.potions.effect;
 
-import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.entitySystem.event.ReceiveEvent;
-import org.terasology.logic.actions.ActionTarget;
 import org.terasology.logic.actions.ExplosionActionComponent;
-import org.terasology.logic.health.DoDamageEvent;
 import org.terasology.potions.HerbEffect;
-import org.terasology.potions.events.DrinkPotionEvent;
-import org.terasology.world.block.Block;
 
 /**
  * This effect destroys blocks in a predefined block radius (the built-in one for now)

--- a/src/main/java/org/terasology/potions/effect/HarmEffect.java
+++ b/src/main/java/org/terasology/potions/effect/HarmEffect.java
@@ -15,11 +15,12 @@
  */
 package org.terasology.potions.effect;
 
-import org.terasology.logic.health.DoDamageEvent;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.logic.health.event.DoDamageEvent;
+import org.terasology.math.TeraMath;
 import org.terasology.potions.HerbEffect;
-import org.terasology.entitySystem.entity.*;
-import org.terasology.math.*;
-public class HarmEffect implements HerbEffect{
+
+public class HarmEffect implements HerbEffect {
     /**
      * The base amount of harming allowed. It's intended to be later multiplied by the magnitude to get the final
      * harming amount.

--- a/src/main/java/org/terasology/potions/effect/HealEffect.java
+++ b/src/main/java/org/terasology/potions/effect/HealEffect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 MovingBlocks
+ * Copyright 2019 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,7 @@ package org.terasology.potions.effect;
 
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.potions.HerbEffect;
-import org.terasology.logic.health.DoHealEvent;
+import org.terasology.logic.health.event.DoRestoreEvent;
 import org.terasology.math.TeraMath;
 
 /**
@@ -41,7 +41,7 @@ public class HealEffect implements HerbEffect {
      */
     @Override
     public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
-        entity.send(new DoHealEvent(TeraMath.floorToInt(baseHeal * magnitude), instigator));
+        entity.send(new DoRestoreEvent(TeraMath.floorToInt(baseHeal * magnitude), instigator));
     }
 
     /**
@@ -56,6 +56,6 @@ public class HealEffect implements HerbEffect {
      */
     @Override
     public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
-        entity.send(new DoHealEvent(TeraMath.floorToInt(baseHeal * magnitude), instigator));
+        entity.send(new DoRestoreEvent(TeraMath.floorToInt(baseHeal * magnitude), instigator));
     }
 }


### PR DESCRIPTION
Change `DoHealEvent` to `DoRestoreEvent`.

How to test:
1. Checkout PR https://github.com/MovingBlocks/Terasology/pull/3677 branch 
2. Checkout PR https://github.com/Terasology/Health/pull/17 in Health module.
2. Start a new game with Potions and Core (which will add Health).
3. Console command `setRegenRate 0`, so that regeneration does not affect testing restoration
4. Console command `damage 90` to cause damage to player.
5. Test heal potions:
i.   Console command `give Potions:HealPotion`, activate the potion. Health restores by 20
ii.  Console command `give Potions:SuperHealPotion`, activate the potion. Full health restored 
iii. Console command `give Potions:UltraHealPotion`, activate the potion. Full health restored 