### PR TITLE
Add test for restoration potion

### DIFF
--- a/module.txt
+++ b/module.txt
@@ -9,7 +9,8 @@
         {"id" : "Core", "minVersion" : "2.0.0"},
         {"id": "Durability", "minVersion": "1.0.0"},
         {"id" : "Fluid", "minVersion" : "1.0.0"},
-        {"id" : "InGameHelpAPI", "minVersion" : "0.1.0"}
+        {"id" : "InGameHelpAPI", "minVersion" : "0.1.0"},
+        {"id": "ModuleTestingEnvironment","minVersion": "0.1.0", "optional":true}
     ],
     "serverSideOnly" : false
 }

--- a/src/main/java/org/terasology/potions/effect/ExplosiveEffect.java
+++ b/src/main/java/org/terasology/potions/effect/ExplosiveEffect.java
@@ -15,15 +15,9 @@
  */
 package org.terasology.potions.effect;
 
-import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
-import org.terasology.entitySystem.event.ReceiveEvent;
-import org.terasology.logic.actions.ActionTarget;
 import org.terasology.logic.actions.ExplosionActionComponent;
-import org.terasology.logic.health.DoDamageEvent;
 import org.terasology.potions.HerbEffect;
-import org.terasology.potions.events.DrinkPotionEvent;
-import org.terasology.world.block.Block;
 
 /**
  * This effect destroys blocks in a predefined block radius (the built-in one for now)

--- a/src/main/java/org/terasology/potions/effect/HarmEffect.java
+++ b/src/main/java/org/terasology/potions/effect/HarmEffect.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.potions.effect;
 
-import org.terasology.logic.health.DoDamageEvent;
+import org.terasology.logic.health.event.DoDamageEvent;
 import org.terasology.potions.HerbEffect;
 import org.terasology.entitySystem.entity.*;
 import org.terasology.math.*;

--- a/src/main/java/org/terasology/potions/effect/HealEffect.java
+++ b/src/main/java/org/terasology/potions/effect/HealEffect.java
@@ -17,7 +17,7 @@ package org.terasology.potions.effect;
 
 import org.terasology.entitySystem.entity.EntityRef;
 import org.terasology.potions.HerbEffect;
-import org.terasology.logic.health.DoHealEvent;
+import org.terasology.logic.health.event.DoRestoreEvent;
 import org.terasology.math.TeraMath;
 
 /**
@@ -41,7 +41,7 @@ public class HealEffect implements HerbEffect {
      */
     @Override
     public void applyEffect(EntityRef instigator, EntityRef entity, float magnitude, long duration) {
-        entity.send(new DoHealEvent(TeraMath.floorToInt(baseHeal * magnitude), instigator));
+        entity.send(new DoRestoreEvent(TeraMath.floorToInt(baseHeal * magnitude), instigator));
     }
 
     /**
@@ -56,6 +56,6 @@ public class HealEffect implements HerbEffect {
      */
     @Override
     public void applyEffect(EntityRef instigator, EntityRef entity, String id, float magnitude, long duration) {
-        entity.send(new DoHealEvent(TeraMath.floorToInt(baseHeal * magnitude), instigator));
+        entity.send(new DoRestoreEvent(TeraMath.floorToInt(baseHeal * magnitude), instigator));
     }
 }

--- a/src/test/java/org/terasology/potions/HealthPotionTest.java
+++ b/src/test/java/org/terasology/potions/HealthPotionTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019 MovingBlocks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.terasology.potions;
+
+import com.google.api.client.util.Sets;
+import org.junit.Before;
+import org.junit.Test;
+import org.terasology.entitySystem.entity.EntityManager;
+import org.terasology.entitySystem.entity.EntityRef;
+import org.terasology.logic.common.ActivateEvent;
+import org.terasology.logic.health.HealthComponent;
+import org.terasology.logic.inventory.InventoryManager;
+import org.terasology.logic.players.PlayerCharacterComponent;
+import org.terasology.math.geom.Vector3f;
+import org.terasology.moduletestingenvironment.ModuleTestingEnvironment;
+
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class HealthPotionTest extends ModuleTestingEnvironment {
+    private EntityManager entityManager;
+    private InventoryManager inventoryManager;
+
+    @Override
+    public Set<String> getDependencies() {
+        Set<String> modules = Sets.newHashSet();
+        modules.add("Potions");
+        modules.add("Core");
+        return modules;
+    }
+
+    @Before
+    public void initialize() {
+        entityManager = getHostContext().get(EntityManager.class);
+        inventoryManager = getHostContext().get(InventoryManager.class);
+    }
+
+    @Test
+    public void healPotionTest() {
+        final EntityRef player = entityManager.create();
+        player.addComponent(new PlayerCharacterComponent());
+
+        HealthComponent health = new HealthComponent();
+        health.currentHealth = 40;
+        health.maxHealth = 100;
+
+        player.addComponent(health);
+
+        EntityRef healPotion = entityManager.create("Potions:HealPotion");
+
+        inventoryManager.giveItem(player, player, healPotion);
+        ActivateEvent activateEvent = new ActivateEvent(
+                healPotion,             // target
+                player,                 // instigator
+                null,               // origin
+                null,           // direction
+                Vector3f.zero(),        // hit position
+                Vector3f.zero(),        // hit normal
+                0            // activation id
+        );
+
+        player.send(activateEvent);
+        assertEquals(60, player.getComponent(HealthComponent.class).currentHealth);
+    }
+}


### PR DESCRIPTION
Currently not working. The activation of potion by `ActivateEvent()` is not triggering the potion. Hence the test does not pass.

Having some time delay between the activate event and assert doesn't help, implying that the potion hasn't worked, and is not some activation delay of potion

How to test:
Run the test